### PR TITLE
Add test h10: Replace Global RegExp

### DIFF
--- a/bin/tests.json
+++ b/bin/tests.json
@@ -47,5 +47,10 @@
   "h9": {
     "name": "h9: Replace All Literal",
     "fmt": "m,--"
+  },
+
+  "h10": {
+    "name": "h10: Replace Global RegExp",
+    "fmt": "m,--"
   }
 }

--- a/public/common.js
+++ b/public/common.js
@@ -163,6 +163,15 @@ const FNS = (() => {
       .replaceAll('"', '&quot;');
   };
 
+  // html escape (replace global regex)
+  const h9 = (v) => {
+    return v.replace(/\&/g, '&amp;')
+      .replace(/\</g, '&lt;')
+      .replace(/\>/g, '&gt;')
+      .replace(/\'/g, '&apos;')
+      .replace(/\"/g, '&quot;');
+  };
+
 //   // html escape (dom-based)
 //   // note: textContent rather than innerText; the latter does not
 //   // handle newlines correctly
@@ -233,6 +242,12 @@ const FNS = (() => {
     name: "h9: Replace All Literal",
     text: `
       HTML escape series of literal replaceAll()s.
+    `,
+  }, {
+    id: 'h10',
+    name: "h10: Replace Global RegExp",
+    text: `
+      HTML escape series of literal replaces by global regex.
     `,
   }];
 
@@ -322,6 +337,7 @@ const FNS = (() => {
     h7: h7,
     h8: h8,
     h9: h9,
+    h10: h10,
     // hd: hd,
     h: h6,
 

--- a/public/common.js
+++ b/public/common.js
@@ -164,7 +164,7 @@ const FNS = (() => {
   };
 
   // html escape (replace global regex)
-  const h9 = (v) => {
+  const h10 = (v) => {
     return v.replace(/\&/g, '&amp;')
       .replace(/\</g, '&lt;')
       .replace(/\>/g, '&gt;')


### PR DESCRIPTION
Hi Paul,

thanks for your amazing work!

Reporting issues and feature requests seem to be disabled on this repo, so I created a small pull request.

Working on my personal super-tiny JavaScript SSR templating engine,
I discovered that an additional test (added as: h10) seems to be slightly faster than "The Winner: h9".

It would be nice if you could add it,  but of course I know I'm a little late. ;)

Thanks for your precious time
Michael
